### PR TITLE
AJ consulr updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,85 @@ Dynamic puppet manifests using [consul](https://www.consul.io/)
 ## getting started
 Add a key to consul:
 ```
-curl -X PUT <uri>/v1/kv/<nodes_prefix>/<facter_prefix_key>/some_key -d 'some value'
+curl -X PUT <uri>/v1/kv/<nodes_prefix>/<facter_prefix>/some_key -d 'some value'
 ```
 
 Add this line to **site.pp** or some place where it can be called as top-scope variable:
 ```
-$something_fancy = consulr_kv('http://localhost:8500', 'nodes', 'ec2_instance_id')
+$something_fancy = consulr_kv()
 ```
 
 Then you can call `$something_fancy` anywhere in your puppet environment like so:
 ```
-$::something_fancy['some_key']
+$::something_fancy['some-key']
 ```
 
 ## parameters
-`consulr_kv` takes 3 parameters, all are required.
+`consulr_kv` takes a config hash with the following defaults:
 ```
-consulr_kv(uri, nodes_prefix, facter_prefix_key)
+consulr_kv({
+  'uri'           => 'http://localhost:8500',
+  'nodes_prefix'  => 'nodes',
+  'facter_prefix' => 'hostname',
+  'value_only'    => true,
+  'base64_decode' => true,
+  'ignore_404'    => true,
+  'token'         => false,
+  'timeout'       => 5,
+})
 ```
 
 * `uri`: The URI to connect to HTTP API, usually it's `http://localhost:8500` (no trailing `/`).
  
-* `nodes_prefix`: The prefix for all nodes-related keys: `<uri>/<nodes_prefix>/<facter_prefix_key>`.
+* `nodes_prefix`: The prefix for all nodes-related keys: `<uri>/<nodes_prefix>/<facter_prefix>`.
 
-* `facter_prefix_key`: The Facter prefix key is the **name** of the key of one of the facts unique to the node.
+* `facter_prefix`: The Facter prefix is the **name** of the key of one of the facts unique to the node.
 
   * If it's an EC2 instance, the logical choice would be the `ec2_instance_id` fact since it's unique for all the instances and doesn't have too many special characters (ex. `i-a8caf087`)
 
-  * For non-EC2 instances the `hostname` fact is a good choice but `fqdn` is probably not (although it might work). Basically choose something which doesn't have too many special characters, but is unique.
+  * For non-EC2 instances the `hostname` fact is a good choice. Basically choose something which doesn't have too many special characters, but unique.
 
-  * **DO NOT** pass the fact like `$::hostname`, just pass the fact's key name as a string `'hostname'`. For a list of all facts run `facter -p` on the instance.
+  * **DO NOT** pass the fact like `$::hostname`, just pass the fact's name as a string `'hostname'`. For a list of all facts run `facter -p` on the instance.
+
+* `value_only`: If set to `false` it will only return the value of the key in string format. If `true` it will return the entire hash as received from consul.
+
+```
+value_only = true
+--
+"aj test"
+```
+
+```
+value_only = false
+--
+{
+ "CreateIndex":7357,
+ "ModifyIndex":7390,
+ "LockIndex":0,
+ "Key":"aj-test",
+ "Flags":0,
+ "Value":"aj test"
+}
+```
+
+* `base64_decode`: If set to `true` the value returned from consul will automagically be decoded. If you choose to set it to `false` please ensure you use something like `base64()` from puppet-stdlib to convert the "raw" value.
+```
+base64_decode = true
+--
+"aj test"
+```
+
+```
+base64_decode = false
+--
+"YWogdGVzdA=="
+```
+
+* `ignore_404`: If `true` puppet run will not fail when key doesn't exist. If set to `false` and the key is missing, puppet run will fail.
+
+* `token`: Pass an ACL token when querying consul.
+
+* `timeout`: Timeout, in seconds, while talking to the API.
 
 ## A real-world scenario
 Imagine for a minute you want to upgrade Django from 1.5 to 1.6 across 100 instances. You've tested the newer version and decided to upgrade in production.
@@ -41,12 +90,12 @@ Imagine for a minute you want to upgrade Django from 1.5 to 1.6 across 100 insta
 Usually the upgrade is all or nothing, meaning, you can either upgrade Django on all the nodes at once or none at all. But what if you want to do a more controlled rollout? If you want to upgrade in batches of 10, follow the steps below.
 
 * Add a `django_version` key with a value to consul on various instances (you can probably automate this with a simple bash batch script).
-  * The `<facter_prefix_value>` must be unique to each node **and** must come in the beginning of the key name
-    * **BAD**: `/v1/kv/something/<nodes_prefix>/or/the/other/<facter_prefix_value>/django_version`
-    * **GOOD**: `/v1/kv/<nodes_prefix>/<facter_prefix_value>/something/or/the/other/django_version`
+  * The `<facter_prefix>` must be unique to each node **and** must come right after `<nodes_prefix>`
+    * **BAD**: `/v1/kv/something/<nodes_prefix>/or/the/other/<facter_prefix>/django_version`
+    * **GOOD**: `/v1/kv/<nodes_prefix>/<facter_prefix>/something/or/the/other/django_version`
 ```
 Format:
-curl -X PUT <uri>/v1/kv/<nodes_prefix>/<facter_prefix_value>/<key> -d '<value>'
+curl -X PUT <uri>/v1/kv/<nodes_prefix>/<facter_prefix>/<key> -d '<value>'
 
 Example:
 curl -X PUT http://localhost:8500/v1/kv/nodes/i-a8caf087/django_version -d "0.1.6"
@@ -60,7 +109,7 @@ curl -X PUT http://localhost:8500/v1/kv/nodes/i-359717e3/django_version -d "0.1.
 
 * In one of your modules, add a conditional like so:
   * Use the variable as a top-scope (`$::some_var`)
-  * Always omit`<nodes_prefix>/<facter_prefix_value>` from the key name
+  * Always omit`<nodes_prefix>/<facter_prefix>` from the key name
     * **BAD**: `$::consulr_kv['nodes/i-a8caf087/django_version']`
     * **GOOD**: `$::consulr_kv['django_version']`
 ```
@@ -83,9 +132,9 @@ package {'python-django': ensure => $django_version }
 ## go deep (or go home)
 You can call deep-nested keys just as easily:
 ```
-curl -X PUT http://localhost:8500/v1/kv/<nodes_prefix>/<facter_prefix_value>/django/production/version -d "0.1.6"
+curl -X PUT http://localhost:8500/v1/kv/<nodes_prefix>/<facter_prefix>/django/production/version -d "0.1.6"
 ```
-Again, omit `<nodes_prefix>/<facter_prefix_value>` when calling the key:
+Again, omit `<nodes_prefix>/<facter_prefix>` when calling the key:
 ```
 $::consulr_kv['django/production/version'] # 0.1.6
 ```

--- a/lib/puppet/parser/functions/consulr_kv.rb
+++ b/lib/puppet/parser/functions/consulr_kv.rb
@@ -7,41 +7,73 @@ require 'uri'
 module Puppet::Parser::Functions
   newfunction(:consulr_kv, :type => :rvalue) do |args|
 
-    # Lets define some customizable vars
-    uri = args[0] # e.x. http://localhost:8500 (no trailing slash)
-    nodes_prefix = args[1] # <uri>/<nodes_prefix>/<facter_perfix_key> 
-    facter_prefix_key = args[2] # The prefix key unique to each instance
+    # Default config
+    default_config = {
+      'uri'           => 'http://localhost:8500',
+      'nodes_prefix'  => 'nodes',
+      'facter_prefix' => 'hostname',
+      'value_only'    => true,
+      'base64_decode' => true,
+      'ignore_404'    => true,
+      'token'         => false,
+      'timeout'       => 5,
+    }
 
-    # Lets ensure all params are passed
-    raise Puppet::ParseError, 'uri, node prefix and facter prefix key are required' if [uri, nodes_prefix, facter_prefix_key].include?(nil)
-    
+    # Required config options (for future use)
+    required_config = []
+
+    # User config
+    user_config = args.first ? args.first : Hash.new
+
+    # final config
+    config = default_config.merge(user_config)
+
+    # Missing config
+    missing_config = required_config.reject {|i| config.has_key?(i)}
+
+    raise Puppet::ParseError, "Consulr missing config: #{missing_config.join(', ')}" unless missing_config.empty?
+
     # lookupvar returns 'nil' if the fact doesn't exist...
-    prefix = lookupvar(facter_prefix_key)
+    prefix = lookupvar(config['facter_prefix'])
 
     # ...so lets raise hell if thats the case.
-    raise Puppet::ParseError, 'prefix fact not found' if prefix.nil?
+    raise Puppet::ParseError, "Consulr facter prefix not found: #{config['facter_prefix']}" if prefix.nil?
 
     consulr = Hash.new
 
     begin
-      Timeout::timeout(5) do
-        # Get all the keys with facter prefix key
-        uri = URI.parse("#{uri}/v1/kv/#{nodes_prefix}/#{prefix}?recurse")
-        response = Net::HTTP.get_response(uri)
+      Timeout::timeout(config['timeout']) do
+        # Build and parse URI
+        build_uri = "#{config['uri']}/v1/kv/#{config['nodes_prefix']}/#{prefix}?recurse"
+        build_uri << "&token=#{config['token']}" if config['token']
 
-        # If at least one key with the facter prefix is not found,
-        # fail silently
-        raise "HTTP error: #{nodes_prefix}/#{prefix}/ #{response.code} #{response.message}" unless ['200', '404'].include?(response.code)
+        response = Net::HTTP.get_response(URI.parse(build_uri))
+
+        # Following HTTP codes will not raise an exception
+        ignore_http_codes = ['200']
+
+        # Option to ignore 404
+        ignore_http_codes << '404' if config['ignore_404']
+
+        raise Puppet::ParseError, "Consulr HTTP error: #{config['uri']}/v1/kv/#{config['nodes_prefix']}/#{prefix}/ (#{response.code}: #{response.message})" unless ignore_http_codes.include?(response.code)
         data = JSON.parse(response.body) rescue []
 
         # Iterate though the keys and put them in a hash 
         data.each do |kv|
-          # Replace only the first occurence of '<nodes_prefix>/<facter_prefix_key>/'
-          # with blank so when calling in puppet we can omit the facter prefix key.
-          # For example:
-          # $consul['django_version'] instead of $consul['nodes/i-a8caf087/django_version']
-          # but this is OK: $consul['haproxy/webs/i-a8caf087/version']
-          consulr[kv['Key'].sub(/^#{nodes_prefix}\/#{prefix}\//, "")] = Base64.decode64(kv['Value'])
+
+          # We are determining 2 things here:
+          # 1) Whether to send back only value or the entire hash or
+          # 2) Whether to decode the value before sending it back
+          if config['value_only']
+            result = config['base64_decode'] ? Base64.decode64(kv['Value']) : kv['Value']
+          else
+            kv['Value'] = Base64.decode64(kv['Value']) if config['base64_decode']
+            result = kv
+          end
+
+          # Finally remove <nodes_prefix>/<prefix> from the
+          # path and assign that value as the new key
+          consulr[kv['Key'].sub(/^#{config['nodes_prefix']}\/#{prefix}\//, "")] = result
         end
       end
     rescue Timeout::Error => e

--- a/metadata.json
+++ b/metadata.json
@@ -1,34 +1,106 @@
 {
   "name": "venmo-consulr",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "venmo",
-  "summary": "Integrate puppet with consul API",
-  "license": "Apache 2.0",
+  "summary": "Consul library for Puppet",
+  "license": "Apache-2.0",
   "source": "https://github.com/venmo/puppet-consulr",
   "project_page": "https://github.com/venmo/puppet-consulr",
   "issues_url": "https://github.com/venmo/puppet-consulr/issues",
-  "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
     {
-      "operatingsystem": "Ubuntu",
+      "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "10 SP4",
+        "11 SP1",
+        "12"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
+        "6",
         "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2003",
+        "Server 2003 R2",
+        "Server 2008",
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2",
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "5.3",
+        "6.1",
+        "7.1"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">=2.7.20 <4.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
@jbarbuto @jamessthompson 

Added ACL token support and added a couple new features:
- ACL token support
- Pass config via hash for simplicity
- Added sane defaults
- Option to pass token to API
- Option to ignore 404 when keys dont exist
- Option to send back either entire hash or just value
- Option to decode base64 value
- Option to set timeout for API call
- Refactor error handling
- Improve error message text

Forge Metadata changes:
- Add support for many more OS
- Add support for more puppet versions
- Bump version
- Fix license name
- Update description
- Remove stdlib depedency

Updated readme to reflect the new changes.
